### PR TITLE
feat(core): fix #75 enable debugging backend and vscode test extesion

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -9,6 +9,13 @@
 
   // Set *default* container specific settings.json values on container create.
   "settings": {
+    "_workbench.uiExtensions": ["peterjausovec.vscode-docker"],
+    "python.jediEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "pythonTestExplorer.testFramework": "pytest",
+    "python.testing.autoTestDiscoverOnSaveEnabled": true,
+    "python.pythonPath": "/usr/local/bin/python3",
+    "python.testing.pytestPath": "/usr/local/bin/pytest",
     "editor.formatOnSave": false,
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.fontFamily": "Cascadia Code, Fira Code",
@@ -25,12 +32,12 @@
   "extensions": [
     "github.copilot",
     "eamodio.gitlens",
+    "shardulm94.trailing-spaces",
     "esbenp.prettier-vscode",
+    "ms-python.python",
     "gruntfuggly.todo-tree",
     "cweijan.vscode-database-client2",
-    "ms-python.python",
-    "ms-python.vscode-pylance",
-    "davidanson.vscode-markdownlint",
+    "littlefoxteam.vscode-python-test-adapter",
     "ms-azuretools.vscode-docker"
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,8 +1,18 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    // TODO: complete the launch.json
-    "version": "0.2.0",
-    "configurations": []
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug: svc",
+      "type": "python",
+      "request": "attach",
+      "pathMappings": [
+        {
+          "localRoot": "${workspaceFolder}",
+          "remoteRoot": "/workspace"
+        }
+      ],
+      "port": 5678,
+      "host": "localhost"
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "python.testing.pytestArgs": ["backend"],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true,
+  "python.testing.pytestPath": "/usr/local/bin/pytest"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,17 @@
-# base image of the docker container
+# For more information, please refer to https://aka.ms/vscode-docker-python
 FROM python:3.9.1
 
-# set the user to non root
-# RUN useradd -ms /bin/bash appuser -u 1000
+EXPOSE 8000
 
-# USER appuser
-
-# setting enviromenat variable 
+# Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE=1
 
+# Turns off buffering for easier container logging
 ENV PYTHONUNBUFFERED=1
 
-# defining the work directory in the docker container
-WORKDIR /workspace
+# Install pip requirements
+COPY requirements*.txt .
+RUN python -m pip install -r requirements-dev.txt
 
 # copying the requirements.txt file to the work directory
 COPY requirements*.txt ./
@@ -20,9 +19,12 @@ COPY requirements*.txt ./
 # Installing the python requirement on the container
 RUN pip install -r requirements-dev.txt
 
-RUN pip install debugpy -t /tmp
+WORKDIR /workspace
+COPY . /workspace
 
-# copying all local file to the container
-COPY . ./
+# Creates a non-root user with an explicit UID and adds permission to access the /app folder
+# For more info, please refer to https://aka.ms/vscode-docker-python-configure-containers
+RUN adduser -u 5678 --disabled-password --gecos "" appuser && chown -R appuser /workspace
+USER appuser
 
 CMD ["gunicorn", "--bind", "0.0.0.0:8000", "core.wsgi"]

--- a/README.md
+++ b/README.md
@@ -136,8 +136,11 @@ python manage.py makemigrations --dry-run --verbosity 3
 then
 
 ```bash
-python manage.py migrate 
+python manage.py migrate
 ```
+
+You can use, the extension to run the test and the debugger.
+If the debugger is not working, make sure to choose the right Python interpreter.
 
 To run coverage locally you can run
 
@@ -145,7 +148,7 @@ To run coverage locally you can run
 coverage run --omit='*/Doc/*' manage.py test
 ```
 
-Now you can run the command below and open the html file in your fevorite edit and see what tests are missing
+Now you can run the command below open the HTML file in your favorite edit and see what tests are missing
 
 ```bash
 coverage html
@@ -173,7 +176,7 @@ pytest
 > try running the command below and rebuilding the image.
 
 ```bash
-rm -rf /usr/local/lib/node_modules/npm 
+rm -rf /usr/local/lib/node_modules/npm
 ```
 
 ## Docker issues

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,19 +14,20 @@ services:
 
   svc:
     build: .
-    # user: 1000:1000
-    command: bash -c "python manage.py migrate &&
-      python manage.py runserver 0.0.0.0:8000"
     volumes:
       - .:/workspace
     ports:
       - "8000:8000"
+      - "5678:5678"
     environment:
       - POSTGRES_DB=saptable
       - POSTGRES_USER=rootUser
       - POSTGRES_PASSWORD=rootPassword
     depends_on:
       - db
+    command: ["bash", "-c",
+      "pip install debugpy -t /tmp && python /tmp/debugpy --wait-for-client --listen 0.0.0.0:5678 \
+       manage.py runserver 0.0.0.0:8000 --nothreading --noreload"]
   ui:
     # restart: always
     build:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 coverage==6.5.0
-pytest==6.2.4
-pytest-django
+pytest-django==4.5.2
+gunicorn


### PR DESCRIPTION
# Description

This change will enable you to use the debugger from vs code extension for the backend. In addition, you can also use the test from vscode extension.

Fixes #75 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update



